### PR TITLE
Fix tag mismatch warning in SendClientLanguageMessageToAll

### DIFF
--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -557,7 +557,7 @@ stock bool:Player_SetLanguage(const playerid, const string:language[])
             SendClientMessage(i, colour, Player_Language_Get(i, table, identifier));
         #endif
     }
-    return 1;
+    return true;
 }
 
 stock void:Player_SelectLanguage(const playerid)


### PR DESCRIPTION
Resolves a warning 213: tag mismatch by ensuring the SendClientLanguageMessageToAll function consistently adheres to its bool return type. Adjusted the return path to explicitly return a bool value and verified compatibility with SendClientMessage and related macros.