### PR TITLE
PlayerTextDrawLanguageString and TextDrawLanguageStringForPlayer

### DIFF
--- a/example/gamemodes/gamemode.pwn
+++ b/example/gamemodes/gamemode.pwn
@@ -1,21 +1,57 @@
+/*
+ *                               _                                          
+ *   ___  _ __ ___  _ __        | | __ _ _ __   __ _ _   _  __ _  __ _  ___ 
+ *  / _ \| '_ ` _ \| '_ \       | |/ _` | '_ \ / _` | | | |/ _` |/ _` |/ _ \
+ * | (_) | | | | | | |_) | ___  | | (_| | | | | (_| | |_| | (_| | (_| |  __/
+ *  \___/|_| |_| |_| .__/ |___| |_|\__,_|_| |_|\__, |\__,_|\__,_|\__, |\___|
+ *                 |_|                         |___/             |___/      
+ *  
+ !  - omp_language test gamemode created and maintained by KW46 (https://github.com/KW46) (v1.05) 
+ !  - This gamemode demonstrates the functionality of the omp_language include.
+ */
+
+//==============================================================================
+//                       INCLUDES & LIBRARY SETUP
+//==============================================================================
+
 #include <open.mp>
 #include <sscanf2>
 #include <FileManager>
+
 #include <YSI_Coding\y_hooks>
 #include <YSI_Coding\y_va>
 #include <YSI_Data\y_foreach>
 #include <YSI_Visual\y_dialog>
+
 #include <omp_language>
+
+//==============================================================================
+//                        CONSTANTS & DEFINITIONS
+//==============================================================================
 
 #define MAX_FAILED_LOGINS (3)
 
-static spFailedLogins[MAX_PLAYERS];
+//==============================================================================
+//                           STATIC VARIABLES
+//==============================================================================
+
+static 
+    spFailedLogins[MAX_PLAYERS],
+    PlayerText:spWelcomeTextDraw[MAX_PLAYERS]
+;
+
+//==============================================================================
+//                           DIALOG FUNCTIONS
+//==============================================================================
 
 static void:ShowLoginDialog(const playerid)
 {
-    new playerName[MAX_PLAYER_NAME];
-    GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
+    new 
+        playerName[MAX_PLAYER_NAME]
+    ;
 
+    GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
+    
     inline OnAttemptLogin(response, listitem, string:inputtext[])
     {
         #pragma unused listitem
@@ -25,6 +61,9 @@ static void:ShowLoginDialog(const playerid)
             {
                 spFailedLogins[playerid] = 0;
                 SendClientLanguageMessage(playerid, -1, "user-auth", "MESSAGE_LOGIN_OK");
+                
+                PlayerTextDrawLanguageString(playerid, spWelcomeTextDraw[playerid], "user-auth", "WELCOME_MESSAGE", playerName);
+                PlayerTextDrawShow(playerid, spWelcomeTextDraw[playerid]);
             }
             else
             {
@@ -37,7 +76,7 @@ static void:ShowLoginDialog(const playerid)
             }
         }
     }
-
+    
     Dialog_ShowCallback(
         playerid,
         using inline OnAttemptLogin,
@@ -49,18 +88,126 @@ static void:ShowLoginDialog(const playerid)
     );
 }
 
+//==============================================================================
+//                           PLAYER EVENT HOOKS
+//==============================================================================
+
 hook OnPlayerConnect(playerid)
 {
     spFailedLogins[playerid] = 0;
+    
+    spWelcomeTextDraw[playerid] = CreatePlayerTextDraw(playerid, 380.0, 341.15, " ");
+    PlayerTextDrawLetterSize(playerid, spWelcomeTextDraw[playerid], 0.58, 2.42);
+    PlayerTextDrawAlignment(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_ALIGN:2);
+    
+    PlayerTextDrawColour(playerid, spWelcomeTextDraw[playerid], 0xDDDDDBFF);
+    PlayerTextDrawBackgroundColour(playerid, spWelcomeTextDraw[playerid], 0x000000AA);
+    PlayerTextDrawBoxColour(playerid, spWelcomeTextDraw[playerid], 0x00000000);
+    
+    PlayerTextDrawSetShadow(playerid, spWelcomeTextDraw[playerid], 2);
+    PlayerTextDrawSetOutline(playerid, spWelcomeTextDraw[playerid], 0);
+    PlayerTextDrawFont(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_FONT:1);
+    PlayerTextDrawSetProportional(playerid, spWelcomeTextDraw[playerid], true);
+    PlayerTextDrawUseBox(playerid, spWelcomeTextDraw[playerid], true);
+    PlayerTextDrawTextSize(playerid, spWelcomeTextDraw[playerid], 40.0, 460.0);
+    
+    new 
+        playerName[MAX_PLAYER_NAME]
+    ;
 
-    new playerName[MAX_PLAYER_NAME];
     GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
-
     SendClientLanguageMessageToAll(-1, "global", "PLAYER_JOIN", playerName, playerid);
+    
     Player_SelectLanguage(playerid);
+}
+
+hook OnPlayerDisconnect(playerid, reason)
+{
+    PlayerTextDrawDestroy(playerid, spWelcomeTextDraw[playerid]);
+
+    return true;
+}
+
+forward HideWelcomeTextDraw(playerid);
+public HideWelcomeTextDraw(playerid)
+{
+    if (IsPlayerConnected(playerid))
+    {
+        PlayerTextDrawHide(playerid, spWelcomeTextDraw[playerid]);
+    }
+    return true;
 }
 
 hook OnPlayerSelectedLanguage(playerid)
 {
+    new 
+        playerName[MAX_PLAYER_NAME]
+    ;
+
+    GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
+    PlayerTextDrawLanguageString(playerid, spWelcomeTextDraw[playerid], "user-auth", "WELCOME_MESSAGE", playerName);
+    
+    SetTimerEx("HideWelcomeTextDraw", 10000, false, "i", playerid);
+
     ShowLoginDialog(playerid);
 }
+
+//==============================================================================
+//                           GAMEMODE EVENT HOOKS
+//==============================================================================
+
+new 
+    Text:gServerInfoTextDraw
+;
+
+hook OnGameModeInit()
+{
+    gServerInfoTextDraw = TextDrawCreate(320.0, 22.0, " ");
+    TextDrawLetterSize(gServerInfoTextDraw, 0.6, 1.8);
+    TextDrawAlignment(gServerInfoTextDraw, TEXT_DRAW_ALIGN:2);
+    
+    TextDrawColour(gServerInfoTextDraw, 0x906210FF);
+    TextDrawBackgroundColour(gServerInfoTextDraw, 0x000000AA);
+    TextDrawBoxColour(gServerInfoTextDraw, 0x00000000);
+    
+    TextDrawSetShadow(gServerInfoTextDraw, 0);
+    TextDrawSetOutline(gServerInfoTextDraw, 1);
+    TextDrawFont(gServerInfoTextDraw, TEXT_DRAW_FONT:2);
+    TextDrawSetProportional(gServerInfoTextDraw, true);
+    TextDrawUseBox(gServerInfoTextDraw, true);
+    TextDrawTextSize(gServerInfoTextDraw, 200.0, 620.0);
+
+    return true;
+}
+
+forward HideServerInfoTextDraw(playerid);
+public HideServerInfoTextDraw(playerid)
+{
+    if (IsPlayerConnected(playerid))
+    {
+        TextDrawHideForPlayer(playerid, gServerInfoTextDraw);
+    }
+    return true;
+}
+
+hook OnPlayerSpawn(playerid)
+{
+    TextDrawShowForPlayer(playerid, gServerInfoTextDraw);
+
+    TextDrawLanguageStringForPlayer(playerid, gServerInfoTextDraw, "global", "SERVER_INFO");
+
+    SetTimerEx("HideServerInfoTextDraw", 10000, false, "i", playerid);
+
+    return true;
+}
+
+hook OnGameModeExit()
+{
+    TextDrawDestroy(gServerInfoTextDraw);
+
+    return true;
+}
+
+//==============================================================================
+//                              OMP_LANGUAGE
+//==============================================================================

--- a/example/gamemodes/gamemode.pwn
+++ b/example/gamemodes/gamemode.pwn
@@ -51,7 +51,7 @@ static void:ShowLoginDialog(const playerid)
     ;
 
     GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
-    
+
     inline OnAttemptLogin(response, listitem, string:inputtext[])
     {
         #pragma unused listitem
@@ -76,7 +76,7 @@ static void:ShowLoginDialog(const playerid)
             }
         }
     }
-    
+
     Dialog_ShowCallback(
         playerid,
         using inline OnAttemptLogin,
@@ -99,25 +99,25 @@ hook OnPlayerConnect(playerid)
     spWelcomeTextDraw[playerid] = CreatePlayerTextDraw(playerid, 380.0, 341.15, " ");
     PlayerTextDrawLetterSize(playerid, spWelcomeTextDraw[playerid], 0.58, 2.42);
     PlayerTextDrawAlignment(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_ALIGN:2);
-    
+
     PlayerTextDrawColour(playerid, spWelcomeTextDraw[playerid], 0xDDDDDBFF);
     PlayerTextDrawBackgroundColour(playerid, spWelcomeTextDraw[playerid], 0x000000AA);
     PlayerTextDrawBoxColour(playerid, spWelcomeTextDraw[playerid], 0x00000000);
-    
+
     PlayerTextDrawSetShadow(playerid, spWelcomeTextDraw[playerid], 2);
     PlayerTextDrawSetOutline(playerid, spWelcomeTextDraw[playerid], 0);
     PlayerTextDrawFont(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_FONT:1);
     PlayerTextDrawSetProportional(playerid, spWelcomeTextDraw[playerid], true);
     PlayerTextDrawUseBox(playerid, spWelcomeTextDraw[playerid], true);
     PlayerTextDrawTextSize(playerid, spWelcomeTextDraw[playerid], 40.0, 460.0);
-    
+
     new 
         playerName[MAX_PLAYER_NAME]
     ;
 
     GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
     SendClientLanguageMessageToAll(-1, "global", "PLAYER_JOIN", playerName, playerid);
-    
+
     Player_SelectLanguage(playerid);
 }
 
@@ -146,7 +146,7 @@ hook OnPlayerSelectedLanguage(playerid)
 
     GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
     PlayerTextDrawLanguageString(playerid, spWelcomeTextDraw[playerid], "user-auth", "WELCOME_MESSAGE", playerName);
-    
+
     SetTimerEx("HideWelcomeTextDraw", 10000, false, "i", playerid);
 
     ShowLoginDialog(playerid);
@@ -165,11 +165,11 @@ hook OnGameModeInit()
     gServerInfoTextDraw = TextDrawCreate(320.0, 22.0, " ");
     TextDrawLetterSize(gServerInfoTextDraw, 0.6, 1.8);
     TextDrawAlignment(gServerInfoTextDraw, TEXT_DRAW_ALIGN:2);
-    
+
     TextDrawColour(gServerInfoTextDraw, 0x906210FF);
     TextDrawBackgroundColour(gServerInfoTextDraw, 0x000000AA);
     TextDrawBoxColour(gServerInfoTextDraw, 0x00000000);
-    
+
     TextDrawSetShadow(gServerInfoTextDraw, 0);
     TextDrawSetOutline(gServerInfoTextDraw, 1);
     TextDrawFont(gServerInfoTextDraw, TEXT_DRAW_FONT:2);

--- a/example/gamemodes/gamemode.pwn
+++ b/example/gamemodes/gamemode.pwn
@@ -61,9 +61,6 @@ static void:ShowLoginDialog(const playerid)
             {
                 spFailedLogins[playerid] = 0;
                 SendClientLanguageMessage(playerid, -1, "user-auth", "MESSAGE_LOGIN_OK");
-                
-                PlayerTextDrawLanguageString(playerid, spWelcomeTextDraw[playerid], "user-auth", "WELCOME_MESSAGE", playerName);
-                PlayerTextDrawShow(playerid, spWelcomeTextDraw[playerid]);
             }
             else
             {
@@ -94,16 +91,20 @@ static void:ShowLoginDialog(const playerid)
 
 hook OnPlayerConnect(playerid)
 {
+    new 
+        playerName[MAX_PLAYER_NAME]
+    ;
+
+    GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
+
     spFailedLogins[playerid] = 0;
     
-    spWelcomeTextDraw[playerid] = CreatePlayerTextDraw(playerid, 380.0, 341.15, " ");
+    spWelcomeTextDraw[playerid] = CreatePlayerLanguageTextDraw(playerid, 380.0, 341.15, "user-auth", "WELCOME_MESSAGE", playerName);
     PlayerTextDrawLetterSize(playerid, spWelcomeTextDraw[playerid], 0.58, 2.42);
     PlayerTextDrawAlignment(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_ALIGN:2);
-
     PlayerTextDrawColour(playerid, spWelcomeTextDraw[playerid], 0xDDDDDBFF);
     PlayerTextDrawBackgroundColour(playerid, spWelcomeTextDraw[playerid], 0x000000AA);
     PlayerTextDrawBoxColour(playerid, spWelcomeTextDraw[playerid], 0x00000000);
-
     PlayerTextDrawSetShadow(playerid, spWelcomeTextDraw[playerid], 2);
     PlayerTextDrawSetOutline(playerid, spWelcomeTextDraw[playerid], 0);
     PlayerTextDrawFont(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_FONT:1);
@@ -111,11 +112,10 @@ hook OnPlayerConnect(playerid)
     PlayerTextDrawUseBox(playerid, spWelcomeTextDraw[playerid], true);
     PlayerTextDrawTextSize(playerid, spWelcomeTextDraw[playerid], 40.0, 460.0);
 
-    new 
-        playerName[MAX_PLAYER_NAME]
-    ;
+    PlayerTextDrawShow(playerid, spWelcomeTextDraw[playerid]);
 
-    GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
+    
+    
     SendClientLanguageMessageToAll(-1, "global", "PLAYER_JOIN", playerName, playerid);
 
     Player_SelectLanguage(playerid);
@@ -140,13 +140,6 @@ public HideWelcomeTextDraw(playerid)
 
 hook OnPlayerSelectedLanguage(playerid)
 {
-    new 
-        playerName[MAX_PLAYER_NAME]
-    ;
-
-    GetPlayerName(playerid, playerName, MAX_PLAYER_NAME);
-    PlayerTextDrawLanguageString(playerid, spWelcomeTextDraw[playerid], "user-auth", "WELCOME_MESSAGE", playerName);
-
     SetTimerEx("HideWelcomeTextDraw", 10000, false, "i", playerid);
 
     ShowLoginDialog(playerid);

--- a/example/scriptfiles/languages/en_English/global.txt
+++ b/example/scriptfiles/languages/en_English/global.txt
@@ -1,1 +1,2 @@
-PLAYER_JOIN	{YELLOW}[JOIN] {GREY}%s(%d) {WHITE}just entered the server!
+PLAYER_JOIN	    {YELLOW}[JOIN] {GREY}%s(%d) {WHITE}just entered the server!
+SERVER_INFO     Running with omp_language

--- a/example/scriptfiles/languages/en_English/user/auth.txt
+++ b/example/scriptfiles/languages/en_English/user/auth.txt
@@ -5,3 +5,5 @@ DIALOG_BUTTON_LOGIN	    {WHITE}Login
 DIALOG_BUTTON_QUIT	    {RED}Quit
 ERR_WRONG_PASSWORD	    {RED}[ERROR] {WHITE}Wrong password entered! (%d/%d)
 MESSAGE_LOGIN_OK	    {GREEN}[OK] {WHITE}Succesfully logged in!
+ERR_WRONG_PASSWORD      {RED}Wrong password! Attempt %d/%d
+WELCOME_MESSAGE         Welcome back, %s!

--- a/example/scriptfiles/languages/en_English/user/auth.txt
+++ b/example/scriptfiles/languages/en_English/user/auth.txt
@@ -5,5 +5,4 @@ DIALOG_BUTTON_LOGIN	    {WHITE}Login
 DIALOG_BUTTON_QUIT	    {RED}Quit
 ERR_WRONG_PASSWORD	    {RED}[ERROR] {WHITE}Wrong password entered! (%d/%d)
 MESSAGE_LOGIN_OK	    {GREEN}[OK] {WHITE}Succesfully logged in!
-ERR_WRONG_PASSWORD      {RED}Wrong password! Attempt %d/%d
 WELCOME_MESSAGE         Welcome back, %s!

--- a/example/scriptfiles/languages/nl_Nederlands/global.txt
+++ b/example/scriptfiles/languages/nl_Nederlands/global.txt
@@ -1,1 +1,2 @@
 PLAYER_JOIN	{YELLOW}[JOIN] {GREY}%s(%d) {WHITE}is zojuist de server binnen gekomen!
+SERVER_INFO     Draait met omp_language

--- a/example/scriptfiles/languages/nl_Nederlands/user/auth.txt
+++ b/example/scriptfiles/languages/nl_Nederlands/user/auth.txt
@@ -5,3 +5,5 @@ DIALOG_BUTTON_LOGIN	    {WHITE}Login
 DIALOG_BUTTON_QUIT	    {RED}Verlaat
 ERR_WRONG_PASSWORD	    {RED}[ERROR] {WHITE}Verkeerd wachtwoord ingevoerd! (%d/%d)
 MESSAGE_LOGIN_OK	    {GREEN}[OK] {WHITE}Je bent nu ingelogd!
+ERR_WRONG_PASSWORD      {RED}Verkeerd wachtwoord! Poging %d/%d
+WELCOME_MESSAGE         Welkom terug, %s!

--- a/example/scriptfiles/languages/nl_Nederlands/user/auth.txt
+++ b/example/scriptfiles/languages/nl_Nederlands/user/auth.txt
@@ -5,5 +5,4 @@ DIALOG_BUTTON_LOGIN	    {WHITE}Login
 DIALOG_BUTTON_QUIT	    {RED}Verlaat
 ERR_WRONG_PASSWORD	    {RED}[ERROR] {WHITE}Verkeerd wachtwoord ingevoerd! (%d/%d)
 MESSAGE_LOGIN_OK	    {GREEN}[OK] {WHITE}Je bent nu ingelogd!
-ERR_WRONG_PASSWORD      {RED}Verkeerd wachtwoord! Poging %d/%d
 WELCOME_MESSAGE         Welkom terug, %s!

--- a/example/scriptfiles/languages/pt_Portuguese/_omp_language.txt
+++ b/example/scriptfiles/languages/pt_Portuguese/_omp_language.txt
@@ -1,0 +1,6 @@
+# Language file used by the omp_language include, used for showing the language selection dialog
+
+DIALOG_TITLE            {WHITE}Selecione um idioma
+DIALOG_BUTTON_SELECT    {WHITE}Selecionar
+DIALOG_BUTTON_CANCEL    {WHITE}Cancelar
+MSG_SELECTED_LANGUAGE   {WHITE}Seu idioma foi alterado para {GREY}%s{WHITE}.

--- a/example/scriptfiles/languages/pt_Portuguese/global.txt
+++ b/example/scriptfiles/languages/pt_Portuguese/global.txt
@@ -1,0 +1,2 @@
+PLAYER_JOIN	    {YELLOW}[JOIN] {GREY}%s(%d) {WHITE}acabou de entrar no servidor!
+SERVER_INFO     Rodando com omp_language

--- a/example/scriptfiles/languages/pt_Portuguese/user/auth.txt
+++ b/example/scriptfiles/languages/pt_Portuguese/user/auth.txt
@@ -5,5 +5,4 @@ DIALOG_BUTTON_LOGIN	    {WHITE}Entrar
 DIALOG_BUTTON_QUIT	    {RED}Sair
 ERR_WRONG_PASSWORD	    {RED}[ERRO] {WHITE}Senha incorreta digitada! (%d/%d)
 MESSAGE_LOGIN_OK	    {GREEN}[OK] {WHITE}Login realizado com sucesso!
-ERR_WRONG_PASSWORD      {RED}Senha incorreta! Tentativa %d/%d
 WELCOME_MESSAGE         Bem-vindo de volta, %s!

--- a/example/scriptfiles/languages/pt_Portuguese/user/auth.txt
+++ b/example/scriptfiles/languages/pt_Portuguese/user/auth.txt
@@ -1,0 +1,9 @@
+DIALOG_LOGIN_TITLE	    {WHITE}Login
+# Sistema de login muito seguro:
+DIALOG_LOGIN_CONTENT	{WHITE}Bem-vindo de volta {GREY}%s{WHITE}!\nPor favor, digite a senha da sua conta: {GREY}1234
+DIALOG_BUTTON_LOGIN	    {WHITE}Entrar
+DIALOG_BUTTON_QUIT	    {RED}Sair
+ERR_WRONG_PASSWORD	    {RED}[ERRO] {WHITE}Senha incorreta digitada! (%d/%d)
+MESSAGE_LOGIN_OK	    {GREEN}[OK] {WHITE}Login realizado com sucesso!
+ERR_WRONG_PASSWORD      {RED}Senha incorreta! Tentativa %d/%d
+WELCOME_MESSAGE         Bem-vindo de volta, %s!

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -1,4 +1,14 @@
-//Include version: 1.04
+/*
+ *                               _                                          
+ *   ___  _ __ ___  _ __        | | __ _ _ __   __ _ _   _  __ _  __ _  ___ 
+ *  / _ \| '_ ` _ \| '_ \       | |/ _` | '_ \ / _` | | | |/ _` |/ _` |/ _ \
+ * | (_) | | | | | | |_) | ___  | | (_| | | | | (_| | |_| | (_| | (_| |  __/
+ *  \___/|_| |_| |_| .__/ |___| |_|\__,_|_| |_|\__, |\__,_|\__,_|\__, |\___|
+ *                 |_|                         |___/             |___/      
+ *  
+ !  - omp_language include created and maintained by KW46 (https://github.com/KW46) (v1.05) 
+ */
+
 
 #if defined _INC_omp_language
     #endinput
@@ -553,6 +563,70 @@ stock bool:Player_SetLanguage(const playerid, const string:language[])
     }
     return true;
 }
+
+#if defined _INC_y_va
+    stock PlayerTextDrawLanguageString(const playerid, PlayerText:textid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
+    {
+        //Sets a player-textdraw string using the language system
+        //  `playerid`: Player who owns the textdraw
+        //  `textid`: The PlayerTextDraw to set the string for
+        //  `table[]`: Table to get the content from
+        //  `identifier[]`: Identifier from given table to retrieve
+        //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+        //Returns: output of PlayerTextDrawSetString(), thus 1 on success, 0 on failure
+        
+        static
+            text[LANGUAGE_MAX_CONTENT_LENGTH]
+        ;
+       
+        strcopy(text, va_return(Player_Language_Get(playerid, table, identifier, ___(4))));
+        return PlayerTextDrawSetString(playerid, textid, text);
+    }
+#else
+    stock PlayerTextDrawLanguageString(const playerid, PlayerText:textid, const string:table[], const string:identifier[])
+    {
+        //Sets a player-textdraw string using the language system
+        //  `playerid`: Player who owns the textdraw
+        //  `textid`: The PlayerTextDraw to set the string for
+        //  `table[]`: Table to get the content from
+        //  `identifier[]`: Identifier from given table to retrieve
+        //Returns: output of PlayerTextDrawSetString(), thus 1 on success, 0 on failure
+        
+        return PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier));
+    }
+#endif
+
+#if defined _INC_y_va
+    stock TextDrawLanguageStringForPlayer(const playerid, Text:textid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
+    {
+        //Sets a textdraw string for a specific player using the language system
+        //  `playerid`: Player to show the textdraw to
+        //  `textid`: The TextDraw to set the string for
+        //  `table[]`: Table to get the content from
+        //  `identifier[]`: Identifier from given table to retrieve
+        //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+        //Returns: output of TextDrawSetStringForPlayer(), thus 1 on success, 0 on failure
+        
+        static
+            text[LANGUAGE_MAX_CONTENT_LENGTH]
+        ;
+       
+        strcopy(text, va_return(Player_Language_Get(playerid, table, identifier, ___(4))));
+        return TextDrawSetStringForPlayer(textid, playerid, text);
+    }
+#else
+    stock TextDrawLanguageStringForPlayer(const playerid, Text:textid, const string:table[], const string:identifier[])
+    {
+        //Sets a textdraw string for a specific player using the language system
+        //  `playerid`: Player to show the textdraw to
+        //  `textid`: The TextDraw to set the string for
+        //  `table[]`: Table to get the content from
+        //  `identifier[]`: Identifier from given table to retrieve
+        //Returns: output of TextDrawSetStringForPlayer(), thus 1 on success, 0 on failure
+        
+        return TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier));
+    }
+#endif
 
 stock void:Player_SelectLanguage(const playerid)
 {

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -566,67 +566,67 @@ stock bool:Player_SetLanguage(const playerid, const string:language[])
 
 #if defined _INC_y_va
     stock PlayerTextDrawLanguageString(const playerid, PlayerText:textid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
-    {
-        //Sets a player-textdraw string using the language system
-        //  `playerid`: Player who owns the textdraw
-        //  `textid`: The PlayerTextDraw to set the string for
-        //  `table[]`: Table to get the content from
-        //  `identifier[]`: Identifier from given table to retrieve
-        //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
-        //Returns: output of PlayerTextDrawSetString(), thus 1 on success, 0 on failure
-        
-        static
-            text[LANGUAGE_MAX_CONTENT_LENGTH]
-        ;
-       
-        strcopy(text, va_return(Player_Language_Get(playerid, table, identifier, ___(4))));
-        return PlayerTextDrawSetString(playerid, textid, text);
-    }
 #else
     stock PlayerTextDrawLanguageString(const playerid, PlayerText:textid, const string:table[], const string:identifier[])
-    {
-        //Sets a player-textdraw string using the language system
-        //  `playerid`: Player who owns the textdraw
-        //  `textid`: The PlayerTextDraw to set the string for
-        //  `table[]`: Table to get the content from
-        //  `identifier[]`: Identifier from given table to retrieve
-        //Returns: output of PlayerTextDrawSetString(), thus 1 on success, 0 on failure
-        
-        return PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier));
-    }
 #endif
+{
+    //Sets a player-textdraw string using the language system
+    //  `playerid`: Player who owns the textdraw
+    //  `textid`: The PlayerTextDraw to set the string for
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: output of PlayerTextDrawSetString(), thus 1 on success, 0 on failure
+    
+    #if defined _INC_y_va
+        return PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier, ___(4)));
+    #else
+        return PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier));
+    #endif
+}
 
 #if defined _INC_y_va
     stock TextDrawLanguageStringForPlayer(const playerid, Text:textid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
-    {
-        //Sets a textdraw string for a specific player using the language system
-        //  `playerid`: Player to show the textdraw to
-        //  `textid`: The TextDraw to set the string for
-        //  `table[]`: Table to get the content from
-        //  `identifier[]`: Identifier from given table to retrieve
-        //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
-        //Returns: output of TextDrawSetStringForPlayer(), thus 1 on success, 0 on failure
-        
-        static
-            text[LANGUAGE_MAX_CONTENT_LENGTH]
-        ;
-       
-        strcopy(text, va_return(Player_Language_Get(playerid, table, identifier, ___(4))));
-        return TextDrawSetStringForPlayer(textid, playerid, text);
-    }
 #else
     stock TextDrawLanguageStringForPlayer(const playerid, Text:textid, const string:table[], const string:identifier[])
-    {
-        //Sets a textdraw string for a specific player using the language system
-        //  `playerid`: Player to show the textdraw to
-        //  `textid`: The TextDraw to set the string for
-        //  `table[]`: Table to get the content from
-        //  `identifier[]`: Identifier from given table to retrieve
-        //Returns: output of TextDrawSetStringForPlayer(), thus 1 on success, 0 on failure
-        
-        return TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier));
-    }
 #endif
+{
+    //Sets a textdraw string for a specific player using the language system
+    //  `playerid`: Player to show the textdraw to
+    //  `textid`: The TextDraw to set the string for
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: output of TextDrawSetStringForPlayer(), thus 1 on success, 0 on failure
+    
+    #if defined _INC_y_va
+        return TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier, ___(4)));
+    #else
+        return TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier));
+    #endif
+}
+
+#if defined _INC_y_va
+    stock PlayerText:CreatePlayerLanguageTextDraw(const playerid, Float:x, Float:y, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
+#else
+    stock PlayerText:CreatePlayerLanguageTextDraw(const playerid, Float:x, Float:y, const string:table[], const string:identifier[])
+#endif
+{
+    //Creates a player-textdraw using the language system
+    //  `playerid`: Player to create the textdraw for
+    //  `Float:x`: X-Coordinate
+    //  `Float:y`: Y-Coordinate
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: PlayerText:The ID of the created textdraw
+    
+    #if defined _INC_y_va
+        return CreatePlayerTextDraw(playerid, x, y, Player_Language_Get(playerid, table, identifier, ___(5)));
+    #else
+        return CreatePlayerTextDraw(playerid, x, y, Player_Language_Get(playerid, table, identifier));
+    #endif
+}
 
 stock void:Player_SelectLanguage(const playerid)
 {


### PR DESCRIPTION
Added support for both `TextDrawSetStringForPlayer` and `PlayerTextDrawSetString`.  

Added Portuguese version `scriptfiles` and updated the existing strings. Used DeepL for the Dutch, please check if it's wrong.

Did not include `CreatePlayerTextDraw`, as it's redundant, users can create an empty textdraw like in the example gamemode:  
  ```pawn
  CreatePlayerTextDraw(playerid, 380.0, 341.15, " ");
  ```  


The test gamemode might have some excessive formatting, my bad if I went overboard! 😆  