### PR TITLE
v1.05

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+## v1.05 - 2025/03/26
+* Features
+    * Allow sorting languages (see gamemode compile option: LANGUAGE_SORT_LANGUAGES) #22
+    * PlayerTextDrawLanguageString(), TextDrawLanguageStringForPlayer(), CreatePlayerLanguageTextDraw() #21 (by @itsneufox)
+    * SendPlayerLanguageMessageToAll(), SendPlayerLanguageMessageToPlayer() #18
+    * CreatePlayer3DLanguageTextLabel(), UpdatePlayer3DLanguageTextLabelText() #18
+
+* Fixes
+    * Unreachable code warning in On[FilterScript|GameMode]Init() when not using YSI #22
+
+* Misc
+    * Query db for each language instead of for each player in 'to all' functions #22
+
+## v1.04 - 2025/03/22
+* Features
+    * N/A
+
+* Fixes
+    * Wrong variable name #19 (happened in a silent patch - shame on me!)
+    * Tag mismatch warning #17 (by @NebulaGB)
+
+* Misc
+    * N/A
+
+## v1.03 - 2025/01/04
+* Features
+    * Prints a warning if language content length exceeds LANGUAGE_MAX_CONTENT_LENGTH #8
+    * GameLanguageTextForPlayer() + GameLanguageTextForAll() #9
+
+* Fixes
+    * Possibility of having incorrect table names #7
+
+* Misc
+    * N/A
+
+## v1.02 - 2024/11/05
+* Features
+    * N/A
+
+* Fixes
+    * N/A
+
+* Misc
+    * Allows excluding YSI explicitly and partially (see gamemode compile options: LANGUAGE_NO_YSI[_\*]) #5
+
+## v1.01 - 2024/08/27
+* Features
+    * N/A
+
+* Fixes
+    * Missing characters when using language files using LF #1
+
+* Misc
+    * For convenience, add include version on top of include file #2
+
+## v1.00 - 2024/07/08
+Initial release

--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ Define this to prevent inclusion of y_foreach.
 Define this to prevent inclusion of y_dialog and y_inline.  
 If not defined, omp_language will attempt to include both y_dialog and y_inline.
 
+`LANGUAGE_SORT_LANGUAGES`  
+readdir() does not guarantee ordering items. Those who want their languages ordered can define LANGUAGE_SORT_LANGUAGES.  
+When defined, you'll also have to define either LANGUAGE_SORT_COUNTRY_NAME **or** LANGUAGE_SORT_COUNTRY_CODE.  
+This requires md-sort to be included (must be in either `(include_path)/md-sort.inc` or `(include_path)/md-sort/md-sort.inc`).  
+Note that YSI provides md-sort already.
+
+`LANGUAGE_SORT_COUNTRY_NAME`  
+Define this to sort languages by language name when sorting languages.  
+
+`LANGUAGE_SORT_COUNTRY_CODE`  
+Define this to sort languages by language code when sorting languages.  
+
+`LANGUAGE_SORT_METHOD`  
+Optional. Define this with either `SORT_ASC` or `SORT_DESC` to order languages ascending or descending.  
+Default value if not defined: `SORT_ASC`
+
 [To index](#how-to-use)
 
 ### Embedded colour names
@@ -224,6 +240,13 @@ Yes.
 * [SendClientLanguageMessageToAll()](#sendclientlanguagemessagetoall)
 * [GameLanguageTextForPlayer()](#gamelanguagetextforplayer)
 * [GameLanguageTextForAll()](#gamelanguagetextforall)
+* [CreatePlayerLanguageTextDraw()](#createplayerlanguagetextdraw)
+* [PlayerTextDrawLanguageString()](#playertextdrawlanguagestring)
+* [TextDrawLanguageStringForPlayer()](#textdrawlanguagestringforplayer)
+* [SendPlayerLanguageMessageToAll()](#sendplayerlanguagemessagetoall)
+* [SendPlayerLanguageMessageToPlayer()](#sendplayerlanguagemessagetoplayer)
+* [CreatePlayer3DLanguageTextLabel()](#createplayer3dlanguagetextlabel)
+* [UpdatePlayer3DLanguageTextLabelText()](#updateplayer3dlanguagetextlabeltext)
 * [OnPlayerSelectLanguage()](#onplayerselectlanguage)
 
 [To main index](#index)
@@ -531,6 +554,178 @@ Nothing
 
 **Related functions/callbacks**  
 * [GameLanguageTextForPlayer()](#gamelanguagetextforplayer)
+
+[To index](#functions-and-callbacks)
+
+---
+#### CreatePlayerLanguageTextDraw
+`PlayerText:CreatePlayerLanguageTextDraw(const playerid, Float:x, Float:y, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)`  
+Creates a player-textdraw using the language system
+
+**Parameters**  
+`playerid`: Player to create the textdraw for  
+`Float:x`: X-coordinate  
+`Float:y`: Y-coordinate  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`OPEN_MP_TAGS:`: (optional) Used for formatting the string if format specifiers were used. Only works when using YSI
+
+**Returns**  
+PlayerText:The ID of the created textdraw
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [PlayerTextDrawLanguageString()](#playertextdrawlanguagestring)
+* [TextDrawLanguageStringForPlayer()](#textdrawlanguagestringforplayer)
+
+[To index](#functions-and-callbacks)
+
+---
+#### PlayerTextDrawLanguageString
+`PlayerTextDrawLanguageString(const playerid, PlayerText:textid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)`  
+Sets a player-textdraw string using the language system
+
+**Parameters**  
+`playerid`: Player who owns the textdraw  
+`textid`:  The PlayerTextDraw to set the string for  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`OPEN_MP_TAGS:`: (optional) Used for formatting the string if format specifiers were used. Only works when using YSI
+
+**Returns**  
+Always returns 1
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [CreatePlayerLanguageTextDraw()](#createplayerlanguagetextdraw)
+* [TextDrawLanguageStringForPlayer()](#textdrawlanguagestringforplayer)
+
+[To index](#functions-and-callbacks)
+
+---
+#### TextDrawLanguageStringForPlayer
+`TextDrawLanguageStringForPlayer(const playerid, Text:textid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)`  
+Sets a textdraw string for a specific player using the language system
+
+**Parameters**  
+`playerid`: Player to show the textdraw to  
+`textid`: The TextDraw to set the string for  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`OPEN_MP_TAGS:`: (optional) Used for formatting the string if format specifiers were used. Only works when using YSI
+
+**Returns**  
+Always returns 1
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [CreatePlayerLanguageTextDraw()](#createplayerlanguagetextdraw)
+* [PlayerTextDrawLanguageString()](#playertextdrawlanguagestring)
+
+[To index](#functions-and-callbacks)
+
+---
+#### SendPlayerLanguageMessageToAll
+`bool:SendPlayerLanguageMessageToAll(const senderid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)`  
+Sends a message in the name of a player to all other players on the server using the language system
+
+**Parameters**  
+`senderid`: The ID of the sender. If invalid, the message will not be sent  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)  
+
+**Returns**  
+Always returns true
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [SendPlayerLanguageMessageToPlayer()](#sendplayerlanguagemessagetoplayer)
+
+[To index](#functions-and-callbacks)
+
+---
+#### SendPlayerLanguageMessageToPlayer
+`bool:SendPlayerLanguageMessageToPlayer(const playerid, const senderid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)`  
+Sends a message in the name of a player to another player on the server using the language system
+
+**Parameters**  
+`playerid`: The ID of the player who will receive the message  
+`senderid`: The ID of the sender. If invalid, the message will not be sent  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)  
+
+**Returns**  
+Output of SendPlayerMessageToPlayer(), thus **true**: function executed successfully or **false**: Failed to execute (specified player does not exist)
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [SendPlayerLanguageMessageToAll()](#sendplayerlanguagemessagetoall)
+
+[To index](#functions-and-callbacks)
+
+---
+#### CreatePlayer3DLanguageTextLabel
+`PlayerText3D:CreatePlayer3DLanguageTextLabel(const playerid, const string:table[], const string:identifier[], const colour, const Float:x, const Float:y, const Float:z, const Float:drawDistance, const parentPlayerid = INVALID_PLAYER_ID, const parentVehicleid = INVALID_VEHICLE_ID, const bool:testLOS = false, OPEN_MP_TAGS:...)`  
+Creates a 3D text label for a specific player using the language system
+
+**Parameters**  
+`playerid`: The ID of the player to create the 3D text label for  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`colour`: The text colour  
+`Float:x`: X coordinate (or offset if attached)  
+`Float:y`: Y coordinate (or offset if attached)  
+`Float:z`: Z coordinate (or offest if attached)  
+`Float:drawDistance`: The distance where you are able to see the 3D Text Label  
+`parentPlayerid`: (optional) The player you want to attach the 3D Text Label to (None (and default): INVALID_PLAYER_ID)  
+`parentVehicleid`: (optional) The vehicle you want to attach the 3D Text Label to (None (and default): INVALID_VEHICLE_ID)  
+`testLOS`: Test the line of sight (true) so this text can't be seen through walls - or not (false) (default: false)  
+`OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+
+**Returns**  
+Output of CreatePlayer3DTextLabel(): ID of the newly created label or INVALID_3DTEXT_ID if the Player 3D Text Label limit (MAX_3DTEXT_PLAYER) was reached
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [UpdatePlayer3DLanguageTextLabelText()](#updateplayer3dlanguagetextlabeltext)
+
+[To index](#functions-and-callbacks)
+
+---
+#### UpdatePlayer3DLanguageTextLabelText
+`bool:UpdatePlayer3DLanguageTextLabelText(const playerid, const PlayerText3D:textid, const colour, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)`  
+Updates a player 3D Text Label's text and colour using the language system
+
+**Parameters**  
+`playerid`: The ID of the player for which the 3D Text Label was created  
+`textid`: The 3D Text Label you want to update  
+`colour`: The color the 3D Text Label should have from now on  
+`table[]`: Table to get the content from  
+`identifier[]`: Identifier from given table to retrieve  
+`OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)  
+
+**Returns**  
+Always returns true
+
+**Notes**  
+None
+
+**Related functions/callbacks**  
+* [CreatePlayer3DLanguageTextLabel()](#createplayer3dlanguagetextlabel)
 
 [To index](#functions-and-callbacks)
 

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -5,3 +5,6 @@ Se8870/SA-MP-FileManager:1.5.1 #Originally from JaTochNietDan, this is a const c
 
 # Optional (but highly recommended)
 pawn-lang/YSI-Includes:v5.10.0006
+
+# Optional - only required if 1) LANGUAGE_SORT_LANGUAGES is defined and 2) YSI is not in include path (YSI has md-sort included)
+oscar-broman/md-sort

--- a/example/gamemodes/gamemode.pwn
+++ b/example/gamemodes/gamemode.pwn
@@ -99,6 +99,9 @@ hook OnPlayerConnect(playerid)
 
     spFailedLogins[playerid] = 0;
     
+    //Note that this include does not reset player's language data when a player disconnects.
+    //Therefor, the following textdraw will be shown to the player using the language the previous player with that playerid selected
+    //If no player joined with that playerid previously, the server's default language (LANGUAGE_DEFAULT - or if that doesn't exist, language with ID 0) will be used    
     spWelcomeTextDraw[playerid] = CreatePlayerLanguageTextDraw(playerid, 380.0, 341.15, "user-auth", "WELCOME_MESSAGE", playerName);
     PlayerTextDrawLetterSize(playerid, spWelcomeTextDraw[playerid], 0.58, 2.42);
     PlayerTextDrawAlignment(playerid, spWelcomeTextDraw[playerid], TEXT_DRAW_ALIGN:2);
@@ -114,8 +117,7 @@ hook OnPlayerConnect(playerid)
 
     PlayerTextDrawShow(playerid, spWelcomeTextDraw[playerid]);
 
-    
-    
+    //See previous comment. Same thus counts for this join message
     SendClientLanguageMessageToAll(-1, "global", "PLAYER_JOIN", playerName, playerid);
 
     Player_SelectLanguage(playerid);

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -176,8 +176,10 @@ static void:Language_AddDataFromFile(const languageId, const string:file[], cons
     format(fullPath, sizeof(fullPath), "languages/%s_%s%s%s/%s", sLanguages[languageId][E_LANG_CODE], sLanguages[languageId][E_LANG_NAME], (IsNull(subDir) ? "" : "/"), subDir, file);
     format(tableName, sizeof(tableName), "%s%s%s", subDir, (IsNull(subDir) ? "" : "-"), file);
 
-    for (new i = strlen(tableName); i > 0; i--){
-        if (tableName[i] == '.'){
+    for (new i = strlen(tableName); i > 0; i--)
+    {
+        if (tableName[i] == '.')
+        {
             strdel(tableName, i, strlen(tableName));
             break;
         }
@@ -206,9 +208,8 @@ static void:Language_AddDataFromFile(const languageId, const string:file[], cons
         if (sscanf(languageFileContent, sscanfSpecifier, identifier, content))
             continue;
 
-        if (strlen(content) > LANGUAGE_MAX_CONTENT_LENGTH){
+        if (strlen(content) > LANGUAGE_MAX_CONTENT_LENGTH)
             PrintF("<!>[omp_language] Content length of `%s`:`%s` exceeds LANGUAGE_MAX_CONTENT_LENGTH(%d)", tableName, identifier, LANGUAGE_MAX_CONTENT_LENGTH);
-        }
 
         //Strip "\n" (LF) or "\r\n" (CRLF) at end of line
         if (languageFileCurrentLine < languageFileLines)

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -39,6 +39,46 @@
     #endif
 #endif
 
+#if defined LANGUAGE_SORT_LANGUAGES
+    #undef LANGUAGE_SORT_LANGUAGES
+
+    #if !defined _INC_md_sort
+        #tryinclude <md-sort\md-sort>
+    #endif
+    #if !defined _INC_md_sort
+        #tryinclude <md-sort/md-sort>
+    #endif
+    #if !defined _INC_md_sort
+        #tryinclude <md-sort>
+    #endif
+    #if !defined _INC_md_sort
+        #warning Failed to include md-sort.inc : Languages will not be sorted!
+        #define LANGUAGE_SORT_LANGUAGES(0)
+    #else
+        #define LANGUAGE_SORT_LANGUAGES (1)
+    #endif
+#else
+    #define LANGUAGE_SORT_LANGUAGES (0)
+#endif
+
+#if LANGUAGE_SORT_LANGUAGES
+    #if !defined LANGUAGE_SORT_COUNTRY_NAME && !defined LANGUAGE_SORT_COUNTRY_CODE
+        #error LANGUAGE_SORT_LANGUAGES defined, please also define either LANGUAGE_SORT_COUNTRY_NAME or LANGUAGE_SORT_COUNTRY_CODE
+    #elseif defined LANGUAGE_SORT_COUNTRY_NAME && defined LANGUAGE_SORT_COUNTRY_CODE
+        #error Define either LANGUAGE_SORT_COUNTRY_NAME or LANGUAGE_SORT_COUNTRY_CODE, not both
+    #else
+        #if defined LANGUAGE_SORT_COUNTRY_NAME
+            #define _LANGUAGE_SORT_BY E_LANG_NAME
+        #else
+            #define _LANGUAGE_SORT_BY E_LANG_CODE
+        #endif
+    #endif
+
+    #if !defined LANGUAGE_SORT_METHOD
+        #define LANGUAGE_SORT_METHOD SORT_ASC
+    #endif
+#endif
+
 #if !defined gLanguageColours
     #tryinclude <omp_language_colours>
 #endif
@@ -119,6 +159,9 @@ static bool:Language_ScanLanguages()
         dir:languagesDir,
         dirItem[35],
         dirItemType,
+        #if LANGUAGE_SORT_LANGUAGES
+            languages[MAX_LANGUAGES][E_LANG_DATA],
+        #endif
         languagesAdded
     ;
     languagesDir = dir_open("scriptfiles/languages");
@@ -142,16 +185,39 @@ static bool:Language_ScanLanguages()
 
         for (new i = 0; i < LANGUAGES_MAX; i++)
         {
-            if (IsNull(sLanguages[i][E_LANG_CODE]))
-            {
-                format(sLanguages[i][E_LANG_CODE], 3, langCode);
-                format(sLanguages[i][E_LANG_NAME], 32, langName);
-                languagesAdded++;
-                break;
-            }
+            #if LANGUAGE_SORT_LANGUAGES
+                if (IsNull(languages[i][E_LANG_CODE]))
+                {
+                    format(languages[i][E_LANG_CODE], 3, langCode);
+                    format(languages[i][E_LANG_NAME], 32, langName);
+                    languagesAdded++;
+                    break;
+                }
+            #else
+                if (IsNull(sLanguages[i][E_LANG_CODE]))
+                {
+                    format(sLanguages[i][E_LANG_CODE], 3, langCode);
+                    format(sLanguages[i][E_LANG_NAME], 32, langName);
+                    languagesAdded++;
+                    break;
+                }
+            #endif
         }
     }
     dir_close(languagesDir);
+
+    #if LANGUAGE_SORT_LANGUAGES
+        SortDeepArray(languages, _LANGUAGE_SORT_BY, .order = LANGUAGE_SORT_METHOD);
+
+        for (new i = 0, j = -1; i < MAX_LANGUAGES; i++)
+        {
+            if (!IsNull(languages[i][E_LANG_CODE]))
+            {
+                format(sLanguages[++j][E_LANG_CODE], 3, languages[i][E_LANG_CODE]);
+                format(sLanguages[j][E_LANG_NAME], 32, languages[i][E_LANG_NAME]);
+            }
+        }
+    #endif
     return true;
 }
 

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -6,7 +6,10 @@
  *  \___/|_| |_| |_| .__/ |___| |_|\__,_|_| |_|\__, |\__,_|\__,_|\__, |\___|
  *                 |_|                         |___/             |___/      
  *  
- !  - omp_language include created and maintained by KW46 (https://github.com/KW46) (v1.05) 
+ !  - omp_language include created and maintained by @KW46 (Kwarde) (https://github.com/KW46) (v1.05) 
+ !  - Contributors:
+        @NebulaGB (WookieLeaks) (#17)
+        @itsneufox (newfox) (#21)
  */
 
 

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -758,6 +758,63 @@ stock void:Player_SelectLanguage(const playerid)
             GameTextForPlayer(i, fetchedData[Language_GetIDFromData(Player_GetLanguage(i))], time, style);
 }
 
+#if defined _INC_y_va
+    stock bool:SendPlayerLanguageMessageToAll(const senderid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
+#else
+    stock bool:SendPlayerLanguageMessageToAll(const senderid, const string:table[], const string:identifier[])
+#endif
+{
+    //Sends a message in the name of a player to all other players on the server using the language system
+    //  `senderid`: The ID of the sender. If invalid, the message will not be sent
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: Always returns true
+
+    new fetchedData[LANGUAGES_MAX][LANGUAGE_MAX_CONTENT_LENGTH];
+
+    for (new i = 0; i < LANGUAGES_MAX; i++)
+    {
+        if (IsNull(sLanguages[i][E_LANG_NAME]))
+            break;
+
+        #if defined _INC_y_va
+            format(fetchedData[i], LANGUAGE_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(3)));
+        #else
+            format(fetchedData[i], LANGUAGE_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier));
+        #endif
+    }
+
+    #if defined _INC_y_iterate
+        foreach (new i : Player)
+    #else
+        for (new i = 0; i < MAX_PLAYERS; i++) if (IsPlayerConnected(i))
+    #endif
+           SendPlayerMessageToPlayer(i, senderid, fetchedData[Language_GetIDFromData(Player_GetLanguage(i))]);    
+    return true;
+}
+
+#if defined _INC_y_va
+    stock bool:SendPlayerLanguageMessageToPlayer(const playerid, const senderid, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
+#else
+    stock bool:SendPlayerLanguageMessageToPlayer(const playerid, const senderid, const string:table[], const string:identifier[])
+#endif
+{
+    //Sends a message in the name of a player to another player on the server using the language system
+    //  `playerid`: The ID of the player who will receive the message.
+    //  `senderid`: The ID of the sender. If invalid, the message will not be sent
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: Output of SendPlayerMessageToPlayer(), thus true: function executed successfully or false: Failed ot execute (specified player does not exist)
+
+    #if defined _INC_y_va
+        return SendPlayerMessageToPlayer(playerid, senderid, Player_Language_Get(playerid, table, identifier, ___(4)));
+    #else
+        return SendPlayerMessageToPlayer(playerid, senderid, Player_Language_Get(playerid, table, identifier));
+    #endif
+}
+
 /*-- Callbacks --*/
 forward OnPlayerSelectedLanguage(playerid);
 

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -550,18 +550,28 @@ stock bool:Player_SetLanguage(const playerid, const string:language[])
     //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
     //Returns: (bool) Always returns true
 
+    new fetchedData[LANGUAGES_MAX][LANGUAGE_MAX_CONTENT_LENGTH];
+    //Note that I didn't use array size 128 (which is limit for text output in open.mp)
+    //Some people may have a script that breaks longer messages in multiple messages, so that's why
+
+    for (new i = 0; i < LANGUAGES_MAX; i++)
+    {
+        if (IsNull(sLanguages[i][E_LANG_NAME]))
+            break;
+
+        #if defined _INC_y_va
+            format(fetchedData[i], LANGUAGE_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(3)));
+        #else
+            format(fetchedData[i], LANGUAGE_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier));
+        #endif
+    }
+
     #if defined _INC_y_iterate
         foreach (new i : Player)
     #else
         for (new i = 0; i < MAX_PLAYERS; i++) if (IsPlayerConnected(i))
     #endif
-    {
-        #if defined _INC_y_va
-            SendClientMessage(i, colour, Player_Language_Get(i, table, identifier, ___(3)));
-        #else
-            SendClientMessage(i, colour, Player_Language_Get(i, table, identifier));
-        #endif
-    }
+            SendClientMessage(i, colour, fetchedData[Language_GetIDFromData(Player_GetLanguage(i))]);
     return true;
 }
 
@@ -725,6 +735,8 @@ stock void:Player_SelectLanguage(const playerid)
     //Returns: Nothing
 
     new fetchedData[LANGUAGES_MAX][LANGUAGE_MAX_CONTENT_LENGTH];
+    //Default LANGUAGE_MAX_CONTENT_LENGTH may be too much for a gametext.
+    //Since I couldn't find limits on gametext lengths (except using colour codes beyond the 255th character may crash a client), just going with LANGUAGE_MAX_CONTENT_LENGTH
 
     for (new i = 0; i < LANGUAGES_MAX; i++)
     {
@@ -732,9 +744,9 @@ stock void:Player_SelectLanguage(const playerid)
             break;
 
         #if defined _INC_y_va
-            format(fetchedData[i], LANGUAGES_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(4)));
+            format(fetchedData[i], LANGUAGE_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(4)));
         #else
-            format(fetchedData[i], LANGUAGES_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(4)));
+            format(fetchedData[i], LANGUAGE_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier));
         #endif
     }
 
@@ -789,8 +801,9 @@ forward OnPlayerSelectedLanguage(playerid);
                 return 1;
             #endif        
         #endif
+    #else
+        return 1;
     #endif
-    return 1;
 }
 #if !defined _INC_y_hooks
     #if defined FILTERSCRIPT

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -724,18 +724,26 @@ stock void:Player_SelectLanguage(const playerid)
     //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
     //Returns: Nothing
 
+    new fetchedData[LANGUAGES_MAX][LANGUAGE_MAX_CONTENT_LENGTH];
+
+    for (new i = 0; i < LANGUAGES_MAX; i++)
+    {
+        if (IsNull(sLanguages[i][E_LANG_NAME]))
+            break;
+
+        #if defined _INC_y_va
+            format(fetchedData[i], LANGUAGES_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(4)));
+        #else
+            format(fetchedData[i], LANGUAGES_MAX_CONTENT_LENGTH, Language_Get(sLanguages[i][E_LANG_CODE], table, identifier, ___(4)));
+        #endif
+    }
+
     #if defined _INC_y_iterate
         foreach (new i : Player)
     #else
         for (new i = 0; i < MAX_PLAYERS; i++) if (IsPlayerConnected(i))
     #endif
-    {
-        #if defined _INC_y_va
-            GameTextForPlayer(i, Player_Language_Get(i, table, identifier), time, style, ___(4));
-        #else
-            GameTextForPlayer(i, Player_Language_Get(i, table, identifier), time, style);
-        #endif
-    }
+            GameTextForPlayer(i, fetchedData[Language_GetIDFromData(Player_GetLanguage(i))], time, style);
 }
 
 /*-- Callbacks --*/

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -653,13 +653,14 @@ stock bool:Player_SetLanguage(const playerid, const string:language[])
     //  `table[]`: Table to get the content from
     //  `identifier[]`: Identifier from given table to retrieve
     //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
-    //Returns: output of PlayerTextDrawSetString(), thus 1 on success, 0 on failure
+    //Returns: Always returns 1
     
     #if defined _INC_y_va
-        return PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier, ___(4)));
+        PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier, ___(4)));
     #else
-        return PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier));
+        PlayerTextDrawSetString(playerid, textid, Player_Language_Get(playerid, table, identifier));
     #endif
+    return 1;
 }
 
 #if defined _INC_y_va
@@ -674,13 +675,14 @@ stock bool:Player_SetLanguage(const playerid, const string:language[])
     //  `table[]`: Table to get the content from
     //  `identifier[]`: Identifier from given table to retrieve
     //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
-    //Returns: output of TextDrawSetStringForPlayer(), thus 1 on success, 0 on failure
+    //Returns: Always returns 1
     
     #if defined _INC_y_va
-        return TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier, ___(4)));
+        TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier, ___(4)));
     #else
-        return TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier));
+        TextDrawSetStringForPlayer(textid, playerid, Player_Language_Get(playerid, table, identifier));
     #endif
+    return 1;
 }
 
 #if defined _INC_y_va

--- a/includes/omp_language.inc
+++ b/includes/omp_language.inc
@@ -815,6 +815,60 @@ stock void:Player_SelectLanguage(const playerid)
     #endif
 }
 
+//native PlayerText3D:CreatePlayer3DTextLabel(playerid, const text[], colour, Float:x, Float:y, Float:z, Float:drawDistance, parentPlayerid = INVALID_PLAYER_ID, parentVehicleid = INVALID_VEHICLE_ID, bool:testLOS = false, OPEN_MP_TAGS:...);
+//native bool:UpdatePlayer3DTextLabelText(playerid, PlayerText3D:textid, colour, const text[], OPEN_MP_TAGS:...);
+
+#if defined _INC_y_va
+    stock PlayerText3D:CreatePlayer3DLanguageTextLabel(const playerid, const string:table[], const string:identifier[], const colour, const Float:x, const Float:y, const Float:z, const Float:drawDistance, const parentPlayerid = INVALID_PLAYER_ID, const parentVehicleid = INVALID_VEHICLE_ID, const bool:testLOS = false, OPEN_MP_TAGS:...)
+#else
+    stock PlayerText3D:CreatePlayer3DLanguageTextLabel(const playerid, const string:table[], const string:identifier[], const colour, const Float:x, const Float:y, const Float:z, const Float:drawDistance, const parentPlayerid = INVALID_PLAYER_ID, const parentVehicleid = INVALID_VEHICLE_ID, const bool:testLOS = false)
+#endif
+{
+    //Creates a 3D text label for a specific player using the language system
+    //  `playerid`: The ID of the player to create the 3D text label for
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `colour`: The text colour
+    //  `Float:x`: X coordinate (or offset if attached)
+    //  `Float:y`: Y coordinate (or offset if attached)
+    //  `Float:z`: Z coordinate (or offest if attached)
+    //  `Float:drawDistance`: The distance where you are able to see the 3D Text Label
+    //  `parentPlayerid`: The player you want to attach the 3D Text Label to (None: INVALID_PLAYER_ID)
+    //  `parentVehicleid`: The vehicle you want to attach the 3D Text Label to (None: INVALID_VEHICLE_ID)
+    //  `testLOS`: Test the line of sight (true) so this text can't be seen through walls - or not (false)
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: Output of CreatePlayer3DTextLabel(): ID of the newly created label or INVALID_3DTEXT_ID if the Player 3D Text Label limit (MAX_3DTEXT_PLAYER) was reached
+    
+    #if defined _INC_y_va
+        return CreatePlayer3DTextLabel(playerid, Player_Language_Get(playerid, table, identifier, ___(11)), colour, x, y, z, drawDistance, parentPlayerid, parentVehicleid, testLOS);
+    #else
+        return CreatePlayer3DTextLabel(playerid, Player_Language_Get(playerid, table, identifier), colour, x, y, z, drawDistance, parentPlayerid, parentVehicleid, testLOS);
+    #endif
+}
+
+#if defined _INC_y_va
+    stock bool:UpdatePlayer3DLanguageTextLabelText(const playerid, const PlayerText3D:textid, const colour, const string:table[], const string:identifier[], OPEN_MP_TAGS:...)
+#else
+    stock bool:UpdatePlayer3DLanguageTextLabelText(const playerid, const PlayerText3D:textid, const colour, const string:table[], const string:identifier[])
+#endif
+{
+    //Updates a player 3D Text Label's text and colour using the language system
+    //  `playerid`: The ID of the player for which the 3D Text Label was created
+    //  `textid`: The 3D Text Label you want to update
+    //  `colour`: The color the 3D Text Label should have from now on
+    //  `table[]`: Table to get the content from
+    //  `identifier[]`: Identifier from given table to retrieve
+    //  `OPEN_MP_TAGS:...` (optional) Used for formatting format specifiers used in retrieved content <!>ONLY WHEN USING Y_VA(YSI)
+    //Returns: Always return true
+
+    #if defined _INC_y_va
+        UpdatePlayer3DTextLabelText(playerid, textid, colour, Player_Language_Get(playerid, table, identifier, ___(5)));
+    #else
+        UpdatePlayer3DTextLabelText(playerid, textid, colour, Player_Language_Get(playerid, table, identifier));
+    #endif
+    return true;
+}
+
 /*-- Callbacks --*/
 forward OnPlayerSelectedLanguage(playerid);
 


### PR DESCRIPTION
- 'to all' functions don't query db for each player anymore, instead once per language
- PlayerTextDrawLanguageString, TextDrawLanguageStringForPlayer, CreatePlayerLanguageTextDraw by @itsneufox
- SendPlayerLanguageMessageToAll, SendPlayerLanguageMessageToPlayer, CreatePlayer3DLanguageTextLabel, UpdatePlayer3DLanguageTextLabelText
- Fix unreachable code in On[FilterScript\GameMode]Init() when not using YSI
- Allow sorting languages